### PR TITLE
Parse MSB and LSB from pitch bend and song position messages when using midilib gem

### DIFF
--- a/lib/nibbler/midilib.rb
+++ b/lib/nibbler/midilib.rb
@@ -41,9 +41,9 @@ module Nibbler
       MIDI::SystemExclusive.new(args)
     end
 
-    def system_common(second_nibble, data_byte1 = nil, _data_byte2 = nil)
+    def system_common(second_nibble, data_byte1 = nil, data_byte2 = nil)
       case second_nibble
-      when 0x2 then MIDI::SongPointer.new(data_byte1) # similar issue to pitch bend here
+      when 0x2 then MIDI::SongPointer.new(data_byte2 * 128 + data_byte1)
       when 0x3 then MIDI::SongSelect.new(data_byte1)
       when 0x6 then MIDI::TuneRequest.new
       end

--- a/lib/nibbler/midilib.rb
+++ b/lib/nibbler/midilib.rb
@@ -34,9 +34,7 @@ module Nibbler
     end
 
     def pitch_bend(second_nibble, data_byte1, data_byte2)
-      # to-do handle the midilib lsb/msb
-      # right now the second data byte is being thrown away
-      MIDI::PitchBend.new(second_nibble, data_byte1, data_byte2)
+      MIDI::PitchBend.new(second_nibble, data_byte2 * 128 + data_byte1)
     end
 
     def system_exclusive(*args)

--- a/spec/integration/midilib_spec.rb
+++ b/spec/integration/midilib_spec.rb
@@ -89,11 +89,11 @@ describe Nibbler::Midilib do
   end
 
   context 'when song pointer' do
-    let(:message) { lib.system_common(0x2, 0xF0) }
+    let(:message) { lib.system_common(0x2, 0x6d, 0x01) }
 
     it 'returns correct message' do
       expect(message).to be_a(MIDI::SongPointer)
-      expect(message.pointer).to eq(0xF0)
+      expect(message.pointer).to eq(237)
     end
   end
 

--- a/spec/integration/midilib_spec.rb
+++ b/spec/integration/midilib_spec.rb
@@ -70,14 +70,12 @@ describe Nibbler::Midilib do
   end
 
   context 'when pitch bend' do
-    # to-do handle the midilib lsb/msb
-    # right now the second data byte is being thrown away
-    let(:message) { lib.pitch_bend(0x0, 0x20, 0x00) }
+    let(:message) { lib.pitch_bend(0x0, 0x10, 0x3f) }
 
     it 'returns correct message' do
       expect(message).to be_a(MIDI::PitchBend)
       expect(message.channel).to eq(0)
-      expect(message.value).to eq(0x20)
+      expect(message.value).to eq(8080)
     end
   end
 


### PR DESCRIPTION
This change computes the full value parameter using both MSB and LSB for the `MIDI::PitchBend` and `MIDI::SongPointer` message types from the midilib gem.  I updated the specs to match.

I used multiplication and addition rather than bitwise operations (shift and or) because `*` and `+` benchmarked much faster than `<<` and `|`.

Thanks for writing nibbler!